### PR TITLE
Update the manifest for logback-bytebuddy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@
  */
 plugins {
     id 'java'
-    id 'com.gradle.build-scan'         version '2.2.1'
     id "org.shipkit.java"              version "2.2.5"
     id "com.github.hierynomus.license" version "0.15.0"
 	id 'com.diffplug.gradle.spotless'  version '3.24.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip

--- a/logback-bytebuddy/logback-bytebuddy.gradle
+++ b/logback-bytebuddy/logback-bytebuddy.gradle
@@ -30,6 +30,15 @@ dependencies {
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
+jar {
+    manifest {
+        attributes "Premain-Class": "com.tersesystems.logback.bytebuddy.LogbackInstrumentationAgent"
+        attributes "Agent-Class": "com.tersesystems.logback.bytebuddy.LogbackInstrumentationAgent"
+        attributes "Can-Redefine-Classes": "true"
+        attributes "Can-Retransform-Classes": "true"
+    }
+}
+
 shadowJar {
     archiveName = "$baseName-$version.$extension"
 


### PR DESCRIPTION
Broke the manifest for 0.13.1 so using logback-bytebuddy didn't work using the shadow.

This adds back the manifest for 0.13.2 by hand.

Also upgrade Gradle while I'm at it...