### PR TITLE
Update the ASM Opscode dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,4 @@
-<!---freshmark shields
-output = [
-	 link(shield('Maven central', 'mavencentral', '{{group}}:{{artifactIdMaven}}', 'blue'), 'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22{{group}}%22%20AND%20a%3A%22{{artifactIdMaven}}%22'),
-	link(shield('License CC0', 'license', 'CC0', 'blue'), 'https://tldrlegal.com/license/creative-commons-cc0-1.0-universal'),
-	'',
-	link(image('Travis CI', 'https://travis-ci.org/tersesystems/terse-logback.svg?branch=master'), 'https://travis-ci.org/tersesystems/terse-logback')
-	].join('\n')
--->
-[![Maven central](https://img.shields.io/badge/mavencentral-com.tersesystems.logback%3Alogback--core-blue.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.tersesystems.logback%22%20AND%20a%3A%22logback-core%22)
-[![License CC0](https://img.shields.io/badge/license-CC0-blue.svg)](https://tldrlegal.com/license/creative-commons-cc0-1.0-universal)
-
-[![Travis CI](https://travis-ci.org/tersesystems/terse-logback.svg?branch=master)](https://travis-ci.org/tersesystems/terse-logback)
-<!---freshmark /shields -->
+[![Maven Central](https://img.shields.io/maven-central/v/com.tersesystems.securitybuilder/securitybuilder)](https://search.maven.org/artifact/com.tersesystems.securitybuilder/securitybuilder) [![License CC0](https://img.shields.io/badge/license-CC0-blue.svg)](https://tldrlegal.com/license/creative-commons-cc0-1.0-universal)
 
 # Terse Logback
 

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -33,11 +33,11 @@ See [Application Logging in Java: Tracing 3rd Party Code](https://tersesystems.c
 You'll need to install `logback-bytebuddy` and `logback-tracing`, and provide a `byte-buddy` implementation.
 
 ```
-implementation group: 'com.tersesystems.logback', name: 'logback-classic', version: '0.16.2'
-implementation group: 'com.tersesystems.logback', name: 'logback-bytebuddy', version: '0.16.2'
-implementation group: 'com.tersesystems.logback', name: 'logback-tracing', version: '0.16.2'
+implementation group: 'com.tersesystems.logback', name: 'logback-classic', version: 'LATEST'
+implementation group: 'com.tersesystems.logback', name: 'logback-bytebuddy', version: 'LATEST'
+implementation group: 'com.tersesystems.logback', name: 'logback-tracing', version: 'LATEST'
 
-implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.11.0'
+implementation group: 'net.bytebuddy', name: 'byte-buddy', version: 'LATEST'
 ```
 
 There are two ways you can install instrumentation -- you can do it using an agent, or you can do it manually.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.debug=false
 # Set the memory size of the daemon to be higher because animalsniffer needs it.
 #org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
-bytebuddyVersion     = 1.10.8
+bytebuddyVersion     = 1.11.5
 junitVersion         = 4.12
 junitJupiterVersion  = 5.0.1
 junitVintageVersion  = 4.12.1

--- a/logback-bytebuddy/src/main/java/com/tersesystems/logback/bytebuddy/LoggingInstrumentationByteBuddyBuilder.java
+++ b/logback-bytebuddy/src/main/java/com/tersesystems/logback/bytebuddy/LoggingInstrumentationByteBuddyBuilder.java
@@ -37,6 +37,8 @@ public class LoggingInstrumentationByteBuddyBuilder {
   private static final Class<?> INSTRUMENTATION_ADVICE_CLASS = LoggingInstrumentationAdvice.class;
 
   // Is there a better way to handle upgrades here?
+  // As far as I can tell, we just want the highest number possible.
+  // https://stackoverflow.com/questions/63399682/how-do-i-map-asms-api-version-in-opcodes-to-java-version
   private static final int ASM_API = Opcodes.ASM9;
 
   /**

--- a/logback-bytebuddy/src/main/java/com/tersesystems/logback/bytebuddy/LoggingInstrumentationByteBuddyBuilder.java
+++ b/logback-bytebuddy/src/main/java/com/tersesystems/logback/bytebuddy/LoggingInstrumentationByteBuddyBuilder.java
@@ -36,6 +36,9 @@ public class LoggingInstrumentationByteBuddyBuilder {
 
   private static final Class<?> INSTRUMENTATION_ADVICE_CLASS = LoggingInstrumentationAdvice.class;
 
+  // Is there a better way to handle upgrades here?
+  private static final int ASM_API = Opcodes.ASM9;
+
   /**
    * Creates a builder from the element matchers.
    *
@@ -74,7 +77,7 @@ public class LoggingInstrumentationByteBuddyBuilder {
         MethodList<?> methods,
         int writerFlags,
         int readerFlags) {
-      return new ClassVisitor(Opcodes.ASM5, classVisitor) {
+      return new ClassVisitor(ASM_API, classVisitor) {
         private String className;
         private String source;
 


### PR DESCRIPTION
Logging instrumentation was not able to instrument nested classes, failing with

```
[Byte Buddy] ERROR sun.security.pkcs12.PKCS12KeyStore [null, module java.base, Thread[main,5,main], loaded=true]
java.lang.UnsupportedOperationException: NestMember requires ASM7
```

This is straight forward to fix: ensure that the class visitor is defined with ASM 9 opcodes.