### PR TITLE
Upgrade mkdocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'java'
     id "com.github.hierynomus.license" version "0.15.0"
 	id 'com.diffplug.gradle.spotless'  version '3.24.3'
-    id 'ru.vyarus.mkdocs'              version '2.1.1'
+    id 'ru.vyarus.mkdocs'              version '2.2.0'
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "org.shipkit.shipkit-auto-version" version "1.1.19"
     //id 'org.inferred.processors'    version '2.3.0'


### PR DESCRIPTION
Fix mkdocs depending on a bad version of grgit:

```
Receiver class org.ajoberstar.grgit.Repository does not define or inherit an implementation of the resolved method 'abstract java.lang.Object getProperty(java.lang.String)' of interface groovy.lang.GroovyObject.
```