### PR TITLE
Detach child appenders on shutdown

### DIFF
--- a/logback-censor/src/main/java/com/tersesystems/logback/censor/CensorConverter.java
+++ b/logback-censor/src/main/java/com/tersesystems/logback/censor/CensorConverter.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * <p>Note that this does not filter out marker text or additional information related to the event,
  * i.e. it does not filter out exception text.
  *
- * Note also that the censor converter only picks out one censor from the list.
+ * <p>Note also that the censor converter only picks out one censor from the list.
  *
  * <pre>{@code
  * <conversionRule conversionWord="censor"

--- a/logback-censor/src/test/java/com/tersesystems/logback/censor/CensorActionTest.java
+++ b/logback-censor/src/test/java/com/tersesystems/logback/censor/CensorActionTest.java
@@ -62,7 +62,8 @@ public class CensorActionTest {
     TestAppender test = (TestAppender) root.getAppender("TEST3");
     assertThat(test).isNotNull();
     byte[] bytes = test.getEncoder().encode(createLoggingEvent(root, "hunter3 hunter4"));
-    assertThat(new String(bytes, StandardCharsets.UTF_8)).contains("\"message\":\"[CENSOR3] [CENSOR4]\"");
+    assertThat(new String(bytes, StandardCharsets.UTF_8))
+        .contains("\"message\":\"[CENSOR3] [CENSOR4]\"");
   }
 
   @Test

--- a/logback-censor/src/test/java/com/tersesystems/logback/censor/CensoringJsonGeneratorDecoratorTest.java
+++ b/logback-censor/src/test/java/com/tersesystems/logback/censor/CensoringJsonGeneratorDecoratorTest.java
@@ -36,7 +36,6 @@ public class CensoringJsonGeneratorDecoratorTest {
     censor2.setRegex("message");
     censor2.start();
 
-
     CensoringJsonGeneratorDecorator decorator = new CensoringJsonGeneratorDecorator();
     decorator.setContext(context);
     decorator.addCensor(censor1);

--- a/logback-core/src/main/java/com/tersesystems/logback/core/AbstractAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/AbstractAppender.java
@@ -48,6 +48,11 @@ public abstract class AbstractAppender<E> extends UnsynchronizedAppenderBase<E>
     return aai.iteratorForAppenders();
   }
 
+  public void stop() {
+    super.stop();
+    aai.detachAndStopAllAppenders();
+  }
+
   public Appender<E> getAppender(String name) {
     return aai.getAppender(name);
   }

--- a/logback-core/src/main/java/com/tersesystems/logback/core/CompositeAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/CompositeAppender.java
@@ -31,8 +31,10 @@ public class CompositeAppender<E> extends UnsynchronizedAppenderBase<E>
 
   @Override
   public void stop() {
+    if (isStarted()) {
+      detachAndStopAllAppenders();
+    }
     super.stop();
-    detachAndStopAllAppenders();
   }
 
   @Override

--- a/logback-core/src/main/java/com/tersesystems/logback/core/CompositeAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/CompositeAppender.java
@@ -30,6 +30,12 @@ public class CompositeAppender<E> extends UnsynchronizedAppenderBase<E>
   protected AppenderAttachableImpl<E> aai = new AppenderAttachableImpl<E>();
 
   @Override
+  public void stop() {
+    super.stop();
+    detachAndStopAllAppenders();
+  }
+
+  @Override
   protected void append(E eventObject) {
     aai.appendLoopOnAppenders(eventObject);
   }

--- a/logback-core/src/main/java/com/tersesystems/logback/core/DecoratingAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/DecoratingAppender.java
@@ -63,4 +63,13 @@ public abstract class DecoratingAppender<E, EE extends E> extends Unsynchronized
   public boolean detachAppender(String name) {
     return aai.detachAppender(name);
   }
+
+  public void stop() {
+    if (isStarted()) {
+      if (aai != null) {
+        aai.detachAndStopAllAppenders();
+      }
+    }
+    super.stop();
+  }
 }

--- a/logback-core/src/main/java/com/tersesystems/logback/core/DecoratingAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/DecoratingAppender.java
@@ -66,9 +66,7 @@ public abstract class DecoratingAppender<E, EE extends E> extends Unsynchronized
 
   public void stop() {
     if (isStarted()) {
-      if (aai != null) {
-        aai.detachAndStopAllAppenders();
-      }
+      aai.detachAndStopAllAppenders();
     }
     super.stop();
   }

--- a/logback-core/src/main/java/com/tersesystems/logback/core/SelectAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/SelectAppender.java
@@ -34,8 +34,10 @@ public class SelectAppender<E> extends AppenderBase<E> implements AppenderAttach
 
   @Override
   public void stop() {
+    if (isStarted()) {
+      detachAndStopAllAppenders();
+    }
     super.stop();
-    detachAndStopAllAppenders();
   }
 
   @Override

--- a/logback-core/src/main/java/com/tersesystems/logback/core/SelectAppender.java
+++ b/logback-core/src/main/java/com/tersesystems/logback/core/SelectAppender.java
@@ -35,6 +35,7 @@ public class SelectAppender<E> extends AppenderBase<E> implements AppenderAttach
   @Override
   public void stop() {
     super.stop();
+    detachAndStopAllAppenders();
   }
 
   @Override


### PR DESCRIPTION
When `loggerContext.reset()` is called, it reconfigures Logback -- this causes the root logger to detach and shutdown all appenders.  The decorating appenders do not call `aai.detachAndShutdownAppenders()` on `stop`, and so you can have multiple starts without the previous appender being stopped.